### PR TITLE
Add Weekly Thread Support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -70,6 +70,15 @@ HOSTRESPONSE = "You don't appear to be using an approved host: see " \
                "one of them, but feel free to leave mirrors to host " \
                "in your details comment.{1}".format(RULELINK, CONTACT)
 
+# Post body for the weekly thread
+THREADBODY = "In this thread users can post any screenshot, no matter " \
+             "how close to default it may be, and any question, no mater " \
+             "how stupid they think it may be. You can post anything on " \
+             "topic, in any format you like, and using any host. We hope " \
+             "this gives new users a chance to get some help with any " \
+             "problems they're having and older users a chance to show " \
+             "off their knowledge by helping those in need."
+
 # Warning when haven't added a details comment
 DETAILSWARN = "Please add a {0}.{1}".format(TEMPLATE, CONTACT)
 
@@ -332,6 +341,12 @@ def actions(post):
     approve_host(post, purl, ptitle)
 
 
+def weekly_thread():
+    print("Posting weekly thread...")
+    sub = r.get_subreddit("upmo")
+    thread = sub.submit("Weekly Whatever Thread #test", selftext=THREADBODY)
+
+
 # RUNNING BOT
 
 print("Running on r/" + SUBREDDIT)
@@ -339,15 +354,18 @@ while True:
     print("\nRunning at", strftime("%Y-%m-%d %H:%M:%S"))
     subreddit = r.get_subreddit(SUBREDDIT)
     posts = subreddit.get_new(limit=MAXPOSTS)
+
+    if strftime("%a %H:%M") == "Tue 21:00":
+        weekly_thread()
+
     try:
         with open("oldposts", "r") as file:
             oldposts = [line.strip() for line in file]
     except:
         oldposts = []
+
     for post in posts:
-        if post.id in oldposts:
-            pass
-        else:
+        if post.id not in oldposts:
             actions(post)
 
     # Calculates seconds left in current minute

--- a/bot.py
+++ b/bot.py
@@ -28,6 +28,8 @@ MAXPOSTS = 10
 DELAY = 1800
 # Toggles whether bot reports before removal
 TRUSTME = True
+# Time to post weekly threads
+THREADTIME = "21:00"
 
 # Reddit URL
 RURL = "https://www.reddit.com/"
@@ -38,6 +40,9 @@ MODMSG = RURL + "message/compose?to=%2Fr%2F" + SUBREDDIT
 # Markdown formatted link for details comment template
 TEMPLATE = "[details comment]({0}r/{1}/wiki/info/template)"
 TEMPLATE = TEMPLATE.format(RURL, SUBREDDIT)
+
+
+# MESSAGES
 
 # Message about reporting bot errors
 CONTACT = "\n\n*^[Contact]({0}) ^[us]({0}) ^if ^our ^bot ^has ^messed " \
@@ -70,18 +75,40 @@ HOSTRESPONSE = "You don't appear to be using an approved host: see " \
                "one of them, but feel free to leave mirrors to host " \
                "in your details comment.{1}".format(RULELINK, CONTACT)
 
-# Post body for the weekly thread
-THREADBODY = "In this thread users can post any screenshot, no matter " \
-             "how close to default it may be, and any question, no mater " \
-             "how stupid they think it may be. You can post anything on " \
-             "topic, in any format you like, and using any host. We hope " \
-             "this gives new users a chance to get some help with any " \
-             "problems they're having and older users a chance to show " \
-             "off their knowledge by helping those in need."
-
 # Warning when haven't added a details comment
 DETAILSWARN = "Please add a {0}.{1}".format(TEMPLATE, CONTACT)
 
+# Set threads to be posted on a weekly basis
+THREADS = {
+    "Mon": {
+        "title": "Mockup Mondays",
+        "body": "Got an idea for a great new theme or even a whole setup? "
+                "Then this is the thread for you! Whether it's just sharing "
+                "an idea, requests, or an illustration of the whole shebang "
+                "want to know what you'd like your setup to look like. Just "
+                "comment below and lets get the talk rolling. Shout out to "
+                "our friends over at r/unixmockups who are making a sub "
+                "dedicated to the sharing of these."
+                "\n\n"
+                "If you've already got a work in progress version of your "
+                "creation then please [share it with us]({}) as a post, we'd"
+                "love to see it! Remember to tag [OC] in the title so that "
+                "u/upmo can do its thing".format(RURL + SUBREDDIT + "/submit")
+    },
+    "Wed": {
+        "title": "Whatever Wednesdays",
+        "body": "In this thread users can post any screenshot, no matter "
+                "how close to default it may be, and any question, no mater "
+                "how stupid they think it may be. You can post anything on "
+                "topic, in any format you like, and using any host. We hope "
+                "this gives new users a chance to get some help with any "
+                "problems they're having and older users a chance to show "
+                "off their knowledge by helping those in need."
+    }
+}
+
+
+# DATA
 
 def fillout(list):
     """
@@ -341,10 +368,13 @@ def actions(post):
     approve_host(post, purl, ptitle)
 
 
-def weekly_thread():
-    print("Posting weekly thread...")
-    sub = r.get_subreddit("upmo")
-    thread = sub.submit("Weekly Whatever Thread #test", selftext=THREADBODY)
+def weekly_thread(thread):
+    print("Getting weekly thread...")
+    sub = r.get_subreddit(SUBREDDIT)
+    title = "{} {}".format(thread["title"], strftime("%Y-%m-%d"))
+    print("\tPosting", title, "thread")
+    thread = sub.submit(title, selftext=thread["body"])
+    print("\Done!")
 
 
 # RUNNING BOT
@@ -355,8 +385,9 @@ while True:
     subreddit = r.get_subreddit(SUBREDDIT)
     posts = subreddit.get_new(limit=MAXPOSTS)
 
-    if strftime("%a %H:%M") == "Tue 21:00":
-        weekly_thread()
+    day = strftime("%a")
+    if strftime("%H:%M") == THREADTIME and day in THREADS:
+        weekly_thread(THREADS[day])
 
     try:
         with open("oldposts", "r") as file:

--- a/bot.py
+++ b/bot.py
@@ -29,12 +29,14 @@ DELAY = 1800
 # Toggles whether bot reports before removal
 TRUSTME = True
 # Time to post weekly threads
-THREADTIME = "21:00"
+THREADTIME = "06:00"
 
 # Reddit URL
 RURL = "https://www.reddit.com/"
 # Link to a Reddit's rule page
 RULELINK = RURL + SUBREDDIT + "/about/rules"
+# Direct link to submit a post
+SUBMITURL = RURL + "r/" + SUBREDDIT + "/submit"
 # Direct link to send mod mail
 MODMSG = RURL + "message/compose?to=%2Fr%2F" + SUBREDDIT
 # Markdown formatted link for details comment template
@@ -81,7 +83,7 @@ DETAILSWARN = "Please add a {0}.{1}".format(TEMPLATE, CONTACT)
 # Set threads to be posted on a weekly basis
 THREADS = {
     "Mon": {
-        "title": "Mockup Mondays",
+        "title": "Mockup Monday",
         "body": "Got an idea for a great new theme or even a whole setup? "
                 "Then this is the thread for you! Whether it's just sharing "
                 "an idea, requests, or an illustration of the whole shebang "
@@ -93,17 +95,16 @@ THREADS = {
                 "If you've already got a work in progress version of your "
                 "creation then please [share it with us]({}) as a post, we'd"
                 "love to see it! Remember to tag [OC] in the title so that "
-                "u/upmo can do its thing".format(RURL + SUBREDDIT + "/submit")
+                "u/upmo can do its thing{}".format(SUBMITURL, CONTACT)
     },
-    "Wed": {
-        "title": "Whatever Wednesdays",
-        "body": "In this thread users can post any screenshot, no matter "
-                "how close to default it may be, and any question, no mater "
-                "how stupid they think it may be. You can post anything on "
-                "topic, in any format you like, and using any host. We hope "
-                "this gives new users a chance to get some help with any "
-                "problems they're having and older users a chance to show "
-                "off their knowledge by helping those in need."
+    "Fri": {
+        "title": "Weekly Workshop",
+        "body": "This is a thread to get answers for all your questions, no "
+                "mater how stupid you think it may be. You can also post "
+                "anything on topic, in any format you like, and using any "
+                "host. We hope this gives new users a chance to get some help "
+                "with any problems they're having and older users a chance to "
+                "show off their knowledge by helping those in need." + CONTACT
     }
 }
 
@@ -368,13 +369,16 @@ def actions(post):
     approve_host(post, purl, ptitle)
 
 
-def weekly_thread(thread):
+def weekly_thread(sub, thread):
+    """
+    If a thread exists in the THREADS dictionary for the current day, then at
+    the THREADTIME that thread is posted to the sub as the bottom sticky
+    """
     print("Getting weekly thread...")
-    sub = r.get_subreddit(SUBREDDIT)
     title = "{} {}".format(thread["title"], strftime("%Y-%m-%d"))
     print("\tPosting", title, "thread")
-    thread = sub.submit(title, selftext=thread["body"])
-    print("\Done!")
+    thread = sub.submit(title, selftext=thread["body"]).mod.sticky(bottom=True)
+    print("\tDone!")
 
 
 # RUNNING BOT
@@ -387,7 +391,7 @@ while True:
 
     day = strftime("%a")
     if strftime("%H:%M") == THREADTIME and day in THREADS:
-        weekly_thread(THREADS[day])
+        weekly_thread(subreddit, THREADS[day])
 
     try:
         with open("oldposts", "r") as file:


### PR DESCRIPTION
Adds support for threads to be posted on a weekly basis by the bot:
* taken from a predefined dictionary of post days, titles, and bodies
* limited to max one per each weekday
* time to post taken from `$THREADTIME`